### PR TITLE
[DO-288] network mode가 awsvpc일 경우 ecs service iam 제거

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,6 @@ resource "aws_ecs_service" "this" {
   deployment_maximum_percent         = try(each.value.deployment_maximum_percent, null)
   scheduling_strategy                = try(each.value.scheduling_strategy, "REPLICA")
   health_check_grace_period_seconds  = try(each.value.health_check_grace_period_seconds, null)
-  # iam_role                           = try(each.value.load_balancers, []) != [] ? data.aws_iam_role.service.arn : null
   iam_role                           = var.is_network_mode_awsvpc == true ? null : data.aws_iam_role.service.arn
   wait_for_steady_state              = try(each.value.wait_for_steady_state, true)
   force_new_deployment               = try(each.value.force_new_deployment, false)

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,8 @@ resource "aws_ecs_service" "this" {
   deployment_maximum_percent         = try(each.value.deployment_maximum_percent, null)
   scheduling_strategy                = try(each.value.scheduling_strategy, "REPLICA")
   health_check_grace_period_seconds  = try(each.value.health_check_grace_period_seconds, null)
-  iam_role                           = try(each.value.load_balancers, []) != [] ? data.aws_iam_role.service.arn : null
+  # iam_role                           = try(each.value.load_balancers, []) != [] ? data.aws_iam_role.service.arn : null
+  iam_role                           = var.is_network_mode_awsvpc == true ? null : data.aws_iam_role.service.arn
   wait_for_steady_state              = try(each.value.wait_for_steady_state, true)
   force_new_deployment               = try(each.value.force_new_deployment, false)
   tags                               = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -30,3 +30,8 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "is_network_mode_awsvpc" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
<img width="637" alt="image" src="https://user-images.githubusercontent.com/66547439/173338546-4efe8bc7-f790-40db-ab35-3a501c367ba9.png">

`loadbalancer` 를 사용하는지 체크하는 것이 아닌 `network_mode` 가 `awsvpc` 인지 체크해서 `ecs service iam` 사용 여부를 결정해야 합니다.

기존 코드의 경우 네트워크 모드가 `awsvpc` 여도 로드밸런서 사용 시 IAM을 사용해 다음 에러가 발생합니다.
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/66547439/173338848-7020299a-1b24-47c1-99e3-4fe3c149189d.png">
